### PR TITLE
fix trailing slash so Docker image builds correctly

### DIFF
--- a/inference/Dockerfile
+++ b/inference/Dockerfile
@@ -1,4 +1,4 @@
-ARG FUNCTION_DIR="/function"
+ARG FUNCTION_DIR="/function/"
 
 FROM huggingface/transformers-pytorch-cpu as build-image
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Added trailing slash so Docker image builds correctly and the tutorial works


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
